### PR TITLE
라우팅 prefix 수정

### DIFF
--- a/docs/32-login.md
+++ b/docs/32-login.md
@@ -50,7 +50,7 @@ Route::group(['prefix' => 'auth', 'as' => 'session.'], function () {
 });
 
 /* Password Reminder */
-Route::group(['prefix' => 'password'], function () {
+Route::group(['prefix' => 'auth'], function () {
     Route::get('remind', [
         'as'   => 'reminder.create',
         'uses' => 'Auth\PasswordController@getEmail'


### PR DESCRIPTION
- Before
  Route::group(['prefix' => 'password'], function () {

php artisan route:list
|        | POST         | password/remind          | reminder.store  | Practice\Http\Controllers\Auth\PasswordController@postEmail  | guest      |
|        | GET|HEAD | password/remind          | reminder.create | Practice\Http\Controllers\Auth\PasswordController@getEmail   | guest      |
|        | POST         | password/reset            | reset.store        | Practice\Http\Controllers\Auth\PasswordController@postReset | guest      |
|        | GET|HEAD | password/reset/{token}  | reset.create      | Practice\Http\Controllers\Auth\PasswordController@getReset   | guest      |
- After
  Route::group(['prefix' => 'auth'], function () {

php artisan route:list
|        | POST         | auth/remind          | reminder.store   | Practice\Http\Controllers\Auth\PasswordController@postEmail  | guest      |
|        | GET|HEAD | auth/remind           | reminder.create | Practice\Http\Controllers\Auth\PasswordController@getEmail    | guest      |
|        | POST         | auth/reset             | reset.store        | Practice\Http\Controllers\Auth\PasswordController@postReset  | guest      |
|        | GET|HEAD  | auth/reset/{token} | reset.create       | Practice\Http\Controllers\Auth\PasswordController@getReset    | guest      |
