### PR TITLE
function 기본 인수 오류

### DIFF
--- a/lessons/26-document-model.md
+++ b/lessons/26-document-model.md
@@ -32,8 +32,9 @@ class Document
 {
     private $directory = 'docs';
 
-    public function get($file = 'index.md')
+    public function get($file = null)
     {
+        $file = is_null($file) ? 'index.md' : '';
         if (! File::exists($this->getPath($file))) {
             abort(404, 'File not exist');
         }


### PR DESCRIPTION
http://php.net/manual/kr/functions.arguments.php#functions.arguments.default 
예제 #3 route에서 넘어온 null값으로 인해 기본 인수(index.md)가 들어가지 않습니다.
